### PR TITLE
ui(persona): display nickname in all relevant views

### DIFF
--- a/src/ui/pages/characters/components/ReferenceSelector.tsx
+++ b/src/ui/pages/characters/components/ReferenceSelector.tsx
@@ -267,8 +267,13 @@ export function ReferenceSelector({
                           size="md"
                         />
                         <div className="flex-1 min-w-0">
-                          <div className={cn(typography.body.size, "font-medium text-fg truncate")}>
-                            {name}
+                          <div className={cn(typography.body.size, "flex items-center gap-2 overflow-hidden")}>
+                            <span className="font-medium text-fg truncate">{name}</span>
+                            {type === "persona" && (item as Persona).nickname && (
+                              <span className="shrink-0 rounded-full border border-fg/15 bg-fg/5 px-2 py-0.5 text-[9px] font-medium uppercase tracking-wider text-fg/60">
+                                {(item as Persona).nickname}
+                              </span>
+                            )}
                           </div>
                           {desc && (
                             <div className="text-sm text-fg/50 line-clamp-2 mt-0.5">{desc}</div>

--- a/src/ui/pages/chats/ChatSettings.tsx
+++ b/src/ui/pages/chats/ChatSettings.tsx
@@ -735,10 +735,14 @@ function ChatSettingsContent({ character }: { character: Character }) {
     const currentPersonaId = currentSession?.personaId;
     if (!currentPersonaId) {
       const defaultPersona = personas.find((p) => p.isDefault);
-      return defaultPersona ? `${defaultPersona.title} (default)` : "No persona";
+      if (!defaultPersona) return "No persona";
+      return defaultPersona.nickname
+        ? `${defaultPersona.title} (${defaultPersona.nickname}) (default)`
+        : `${defaultPersona.title} (default)`;
     }
     const persona = personas.find((p) => p.id === currentPersonaId);
-    return persona ? persona.title : "Custom persona";
+    if (!persona) return "Custom persona";
+    return persona.nickname ? `${persona.title} (${persona.nickname})` : persona.title;
   };
 
   const selectedPersonaId = useMemo(() => {

--- a/src/ui/pages/chats/components/ChatHeader.tsx
+++ b/src/ui/pages/chats/components/ChatHeader.tsx
@@ -132,9 +132,12 @@ export function ChatHeader({
   );
 
   const headerTitle = useMemo(() => {
-    if (swapPlaces) return persona?.title ?? "Unknown";
+    if (swapPlaces) {
+      if (!persona) return "Unknown";
+      return persona.nickname ? `${persona.title} (${persona.nickname})` : persona.title;
+    }
     return character?.name ?? "Unknown";
-  }, [character?.name, persona?.title, swapPlaces]);
+  }, [character?.name, persona, swapPlaces]);
 
   return (
     <>

--- a/src/ui/pages/group-chats/components/settings/PersonaSelector.tsx
+++ b/src/ui/pages/group-chats/components/settings/PersonaSelector.tsx
@@ -181,7 +181,7 @@ function PersonaOptionItem({ persona, isSelected, onClick, onLongPress }: Person
 
       {/* Content */}
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 overflow-hidden">
           <span
             className={cn(
               typography.body.size,
@@ -191,6 +191,11 @@ function PersonaOptionItem({ persona, isSelected, onClick, onLongPress }: Person
           >
             {title}
           </span>
+          {persona?.nickname && (
+            <span className="shrink-0 rounded-full border border-fg/15 bg-fg/5 px-2 py-0.5 text-[9px] font-medium uppercase tracking-wider text-fg/60">
+              {persona.nickname}
+            </span>
+          )}
           {isDefault && (
             <span className="inline-flex items-center gap-1 shrink-0 rounded-full border border-info/30 bg-info/10 px-2 py-0.5">
               <Star className="h-2.5 w-2.5 fill-info text-info" />

--- a/src/ui/pages/library/LibraryPage.tsx
+++ b/src/ui/pages/library/LibraryPage.tsx
@@ -717,9 +717,16 @@ const LibraryCard = memo(
 
         {/* Glass Content Area */}
         <div className="relative z-20 flex w-full flex-col gap-1 p-3">
-          <h3 className={cn(typography.body.size, "font-bold text-fg truncate leading-tight")}>
-            {getItemName(item)}
-          </h3>
+          <div className="flex items-center gap-1.5 overflow-hidden">
+            <h3 className={cn(typography.body.size, "font-bold text-fg truncate leading-tight")}>
+              {getItemName(item)}
+            </h3>
+            {item.itemType === "persona" && (item as Persona).nickname && (
+              <span className="shrink-0 rounded-full border border-fg/15 bg-fg/5 px-2 py-0.5 text-[9px] font-medium uppercase tracking-wider text-fg/60">
+                {(item as Persona).nickname}
+              </span>
+            )}
+          </div>
           <p
             className={cn(
               typography.bodySmall.size,

--- a/src/ui/pages/search/SearchPage.tsx
+++ b/src/ui/pages/search/SearchPage.tsx
@@ -379,10 +379,15 @@ const PersonaCard = memo(
 
         {/* Content */}
         <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-1">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 overflow-hidden">
             <h3 className="truncate font-semibold text-[15px] leading-tight text-fg">
               {persona.title}
             </h3>
+            {persona.nickname && (
+              <span className="shrink-0 rounded-full border border-fg/15 bg-fg/5 px-2 py-0.5 text-[9px] font-medium uppercase tracking-wider text-fg/60">
+                {persona.nickname}
+              </span>
+            )}
             {persona.isDefault && (
               <span className="shrink-0 rounded-full bg-accent/20 px-2 py-0.5 text-[10px] font-semibold text-accent">
                 Default

--- a/src/ui/pages/settings/PersonasPage.tsx
+++ b/src/ui/pages/settings/PersonasPage.tsx
@@ -149,7 +149,7 @@ export function PersonasPage() {
                     <div className="flex items-center gap-2 overflow-hidden">
                       <h3 className="truncate text-sm font-semibold text-fg">{persona.title}</h3>
                       {persona.nickname && (
-                        <span className="shrink-0 rounded-md bg-fg/10 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-fg/60">
+                        <span className="shrink-0 rounded-full border border-fg/15 bg-fg/5 px-2 py-0.5 text-[9px] font-medium uppercase tracking-wider text-fg/60">
                           {persona.nickname}
                         </span>
                       )}


### PR DESCRIPTION
## Description

This PR follows up on the Persona Nickname feature (PR #25) by ensuring the nickname is visible across all UI views where a persona appears. While the field was added and displayed in the main Personas settings, it was missing from several other areas where users need to distinguish between persona variants.

## Changes

- **Library & Search:** Added a consistent, muted rounded-full badge for nicknames in the Library and Search results.
- **Selectors:** Added nickname badges to the Group Chat Persona Selector and the Character Reference Selector.
- **Settings & Header:** Included the nickname in parentheses in the Chat Settings active persona display and the Chat Header title.
- **Visual Consistency:** Standardized the nickname badge style to match the existing "Default" indicator while remaining visually distinct.

## Screenshots

*(Nicknames appear as small uppercase labels next to persona titles, e.g., "[WORK VARIANT]")*
<img width="950" height="630" alt="obraz" src="https://github.com/user-attachments/assets/32232d40-dc36-49c2-abf7-fdfa298eb00a" />
<img width="296" height="208" alt="obraz" src="https://github.com/user-attachments/assets/3251784d-ab8b-4f66-a6dc-2f78e07d8f43" />
<img width="694" height="395" alt="obraz" src="https://github.com/user-attachments/assets/dcb868ac-6175-4555-b662-0abac3620b97" />


Tested across all updated views.