### PR TITLE
feat(providers): add opt-in reasoning sync for custom endpoints

### DIFF
--- a/src-tauri/src/chat_manager/provider_adapter/custom.rs
+++ b/src-tauri/src/chat_manager/provider_adapter/custom.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::{OpenAIChatRequest, ProviderAdapter, ReasoningConfig};
 use crate::chat_manager::tooling::{openai_tool_choice, openai_tools, ToolConfig};
@@ -245,7 +245,25 @@ impl ProviderAdapter for CustomGenericAdapter {
             tool_choice,
         };
 
-        serde_json::to_value(request).unwrap()
+        let mut val = serde_json::to_value(request).unwrap();
+
+        // Inject chat_template_kwargs if explicitly enabled in provider config
+        if self
+            .credential_config
+            .as_ref()
+            .and_then(|v| v.get("sendChatTemplateKwargs"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            if let Some(obj) = val.as_object_mut() {
+                obj.insert(
+                    "chat_template_kwargs".to_string(),
+                    json!({ "enable_thinking": reasoning_enabled }),
+                );
+            }
+        }
+
+        val
     }
 }
 

--- a/src/ui/pages/settings/ProvidersPage.tsx
+++ b/src/ui/pages/settings/ProvidersPage.tsx
@@ -785,6 +785,31 @@ export function ProvidersPage() {
                     </div>
                   </>
                 )}
+                {isCustomProvider && (
+                  <div className="flex items-center justify-between pt-1">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-fg/70">Sync Reasoning State</p>
+                      <p className="text-[10px] text-fg/40 leading-tight">
+                        Send template kwargs to synchronize internal thinking state
+                      </p>
+                    </div>
+                    <Switch
+                      id="sendChatTemplateKwargs"
+                      checked={
+                        (editorProvider.config?.sendChatTemplateKwargs as boolean | undefined) ??
+                        false
+                      }
+                      onChange={(next) =>
+                        updateEditorProvider({
+                          config: {
+                            ...editorProvider.config,
+                            sendChatTemplateKwargs: next,
+                          },
+                        })
+                      }
+                    />
+                  </div>
+                )}
                 {validationError && (
                   <p className="text-xs font-medium text-danger/80">{validationError}</p>
                 )}


### PR DESCRIPTION
Ensure that reasoning_enabled state is passed to providers like vLLM and llama.cpp by setting enable_thinking in chat_template_kwargs if not already present.