### PR TITLE
fix(character): support integer type for lorebook entry position

### DIFF
--- a/src-tauri/src/storage_manager/entity_transfer/engine.rs
+++ b/src-tauri/src/storage_manager/entity_transfer/engine.rs
@@ -274,7 +274,7 @@ pub struct CharaCardCharacterBookEntry {
     #[serde(default)]
     pub constant: Option<bool>,
     #[serde(default)]
-    pub position: Option<String>,
+    pub position: Option<JsonValue>,
 }
 
 pub fn looks_like_chara_card_v2(value: &JsonValue) -> bool {


### PR DESCRIPTION
Change the `position` field type in `CharaCardCharacterBookEntry` to handle both integers and strings during JSON deserialization. Some character card exporters output this property as an integer index rather than a string descriptor, which previously caused the entire import process to fail due to a Serde type mismatch.

<img width="1611" height="31" alt="Screenshot_20260522_183732" src="https://github.com/user-attachments/assets/5a031189-875d-4eac-be70-9911c333c5fd" />
