### PR TITLE
fix(build): pin CUDA host compiler to GCC ≤ 15 on Linux

### DIFF
--- a/scripts/run-tauri-cuda-auto.mjs
+++ b/scripts/run-tauri-cuda-auto.mjs
@@ -48,6 +48,28 @@ if (!env.CMAKE_CUDA_ARCHITECTURES && arches.length > 0) {
   );
 }
 
+// CUDA 13.1 cudafe++ chokes on GCC 16 C++20 headers (char8_t, requires).
+// Pick the newest GCC ≤ 15 available as the CUDA host compiler.
+if (process.platform === "linux" && !env.CMAKE_CUDA_HOST_COMPILER && !env.CUDAHOSTCXX) {
+  const candidates = ["/usr/bin/g++-15", "/usr/bin/g++-14", "/usr/bin/g++-13"];
+  const { existsSync } = await import("node:fs");
+  const hostCxx = candidates.find(existsSync);
+  if (hostCxx) {
+    env.CMAKE_CUDA_HOST_COMPILER = hostCxx;
+    env.CUDAHOSTCXX = hostCxx;
+    console.log(`[cuda-auto] CUDA host compiler pinned to ${hostCxx} (avoids GCC 16 incompatibility)`);
+  } else {
+    console.warn("[cuda-auto] No GCC ≤ 15 found — CUDA build may fail with GCC 16 headers. Install gcc15: sudo pacman -S gcc15");
+  }
+}
+
+// Disable NCCL (multi-GPU) — not needed for single-GPU builds.
+// llama-cpp-sys-2 only forwards CMAKE_* env vars to CMake, so we use the
+// standard CMAKE_DISABLE_FIND_PACKAGE mechanism to prevent CMake from
+// detecting NCCL. Without this, CMake enables NCCL but the build.rs never
+// emits cargo:rustc-link-lib=nccl, causing undefined symbol errors.
+env.CMAKE_DISABLE_FIND_PACKAGE_NCCL = env.CMAKE_DISABLE_FIND_PACKAGE_NCCL ?? "TRUE";
+
 // Tauri builds a shared library on Linux; CUDA/C/C++ objects must be PIC-safe.
 // llama-cpp-sys forwards all CMAKE_* env vars into CMake definitions.
 if (process.platform === "linux") {


### PR DESCRIPTION
CUDA 13.1's cudafe++ cannot parse GCC 16's C++20 standard library headers (char8_t, requires-expressions). The build script now auto- detects the newest available GCC ≤ 15 and sets CMAKE_CUDA_HOST_COMPILER and CUDAHOSTCXX accordingly, falling back gracefully with a warning if none is found.

Requires gcc15 on Arch: sudo pacman -S gcc15