### PR TITLE
ci(desktop): fix Windows long-path and Linux Vulkan SPIRV-Headers build breaks

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -590,6 +590,7 @@ jobs:
             libspeechd-dev \
             libvulkan-dev \
             glslc \
+            spirv-headers \
             patchelf \
             zip
 
@@ -711,10 +712,17 @@ jobs:
     runs-on: windows-latest
     env:
       APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enable Windows long paths
+        shell: pwsh
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -871,10 +879,17 @@ jobs:
     runs-on: windows-latest
     env:
       APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enable Windows long paths
+        shell: pwsh
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -1048,10 +1063,17 @@ jobs:
     env:
       APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
       WINDOWS_VULKAN_SDK_VERSION: "1.3.296.0"
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enable Windows long paths
+        shell: pwsh
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/desktop-release-build.yml
+++ b/.github/workflows/desktop-release-build.yml
@@ -584,6 +584,7 @@ jobs:
             libspeechd-dev \
             libvulkan-dev \
             glslc \
+            spirv-headers \
             patchelf \
             zip
 
@@ -694,10 +695,17 @@ jobs:
     runs-on: windows-latest
     env:
       APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enable Windows long paths
+        shell: pwsh
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -851,10 +859,17 @@ jobs:
     runs-on: windows-latest
     env:
       APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enable Windows long paths
+        shell: pwsh
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -1026,10 +1041,17 @@ jobs:
     env:
       APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
       WINDOWS_VULKAN_SDK_VERSION: "1.3.296.0"
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enable Windows long paths
+        shell: pwsh
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Why
Desktop CI (run 27508104374) broke after the llama.cpp submodule bump to `b9611-3` (`ebc10770a`). Two independent build-infra failures, neither in the wrappers:

- **Windows (CPU/CUDA/Vulkan)** — `cargo` could not check out the git dependency: new llama.cpp ships `tools/ui/` (llama-server Svelte WebUI, ~599 files, 161-char paths) which exceeds Windows' 260-char `MAX_PATH` under `.cargo/git/checkouts/...`. libgit2 error `class=Filesystem (30)`.
- **Linux Vulkan** — CMake configure failed at `ggml/src/ggml-vulkan/CMakeLists.txt:14` on `find_package(SPIRV-Headers CONFIG REQUIRED)` (upstream PR #22009); CI never provided SPIRV-Headers.

## Changes (both `desktop-build.yml` and `desktop-release-build.yml`)
- Windows jobs: `CARGO_NET_GIT_FETCH_WITH_CLI: "true"` + an "Enable Windows long paths" step (`git config --system core.longpaths true` + `LongPathsEnabled` registry key) so cargo fetches with system git and long paths work.
- Linux Vulkan job: add `spirv-headers` apt package (cmake config lands under `/usr`, already on CMake's search path).

Windows Vulkan needs only the path fix — the LunarG SDK ships SPIRV-Headers' cmake config and the job exports `VULKAN_SDK`.